### PR TITLE
update 0.4.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tune-sklearn" %}
-{% set version = "0.4.1" %}
+{% set version = "0.4.6" %}
 
 package:
   name: {{ name|lower }}
@@ -9,29 +9,34 @@ source:
   # NOTE: pypi doesnt contain a source package for it. See
   # https://github.com/ray-project/tune-sklearn/issues/159
   url: https://github.com/ray-project/tune-sklearn/archive/v{{ version }}.tar.gz
-  sha256: 8a42e3b4ead768a18a83edb137f00df175abd051fb03b8809b7b66de42d18108
+  sha256: f6d531f99a02de4a420cbefb96de64c8db4a014f2c7352f38a6a7a37e2103614
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
+    - wheel
   run:
-    - python >=3.6
-    - ray-tune >=1.0.1
-    - ray-core >=1.0.1
+    - python
+    - ray-tune >=2.0.0
+    - ray-core >=2.0.0
     - pandas
     - numpy >=1.16
     - scipy
-    - scikit-learn >=0.23
+    - scikit-learn
     - scikit-optimize
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - tune_sklearn
 
@@ -41,7 +46,11 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: A drop-in replacement for Scikit-Learn’s GridSearchCV / RandomizedSearchCV -- but with cutting edge hyperparameter tuning techniques.
+  description: |
+    A drop-in replacement for Scikit-Learn’s GridSearchCV / RandomizedSearchCV -- but with cutting edge hyperparameter tuning techniques.
+  doc_url: https://github.com/ray-project/tune-sklearn/blob/master/README.md
+  dev_url: https://github.com/ray-project/tune-sklearn
 
 extra:
   recipe-maintainers:
-    - hadim
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - python
     - ray-tune >=2.0.0
     - ray-core >=2.0.0
-    - pandas
     - scipy
     - scikit-learn
     - scikit-optimize
@@ -50,7 +49,4 @@ about:
     A drop-in replacement for Scikit-Learn’s GridSearchCV / RandomizedSearchCV -- but with cutting edge hyperparameter tuning techniques.
   doc_url: https://github.com/ray-project/tune-sklearn/blob/master/README.md
   dev_url: https://github.com/ray-project/tune-sklearn
-
-extra:
-  recipe-maintainers:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,10 +26,10 @@ requirements:
   run:
     - python
     - ray-tune >=2.0.0
-    - ray-core >=2.0.0
     - scipy
     - scikit-learn
     - scikit-optimize
+    - {{ pin_compatible('numpy') }}
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<38]
+  skip: True  # [py<38 or ppc64le or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -22,12 +22,12 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - numpy {{ numpy }}
   run:
     - python
     - ray-tune >=2.0.0
     - ray-core >=2.0.0
     - pandas
-    - numpy >=1.16
     - scipy
     - scikit-learn
     - scikit-optimize

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38 or ppc64le or s390x]
+  skip: True  # [py<38 or aarch64 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38 or aarch64 or s390x or ppc64le]
+  skip: True  # [py<38 or py>310 or aarch64 or s390x or ppc64le]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - ray-core >=2.0.0
     - scipy
     - scikit-learn
-    - scikit-optimize
+    # - scikit-optimize
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38 or aarch64 or s390x]
+  skip: True  # [py<38 or aarch64 or s390x or ppc64le]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - ray-core >=2.0.0
     - scipy
     - scikit-learn
-    # - scikit-optimize
+    - scikit-optimize
 
 test:
   requires:


### PR DESCRIPTION
## ☆ Tune-sklearn 0.4.6 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2492)
[Upstream](https://github.com/ray-project/tune-sklearn/tree/v0.4.6)
[Dependencies ](https://github.com/ray-project/tune-sklearn/blob/master/setup.py)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Added `pip` and `pip check` to `tests`
- Added `skip: True # [py<38 or py>310 or aarch64 or s390x or ppc64le]` due to limited availability in defaults for `ray-core` and `ray-tune.` [See here](https://github.com/AnacondaRecipes/ray-packages-feedstock/blob/master/recipe/meta.yaml).
- Updated `about` section